### PR TITLE
Add timeout handling to BaseIO buffer reads

### DIFF
--- a/src/SCPI_RP.cpp
+++ b/src/SCPI_RP.cpp
@@ -59,4 +59,10 @@ void SCPIRedPitaya::initSocket(Stream *serial) {
   acq.trigger.setInterface(s);
   acq.dma.settings.setInterface(s);
   acq.dma.data.setInterface(s);
+  }
+
+void SCPIRedPitaya::setReadTimeout(uint32_t timeout_ms) {
+  if (g_base_io) {
+    g_base_io->setReadTimeout(timeout_ms);
+  }
 }

--- a/src/SCPI_RP.h
+++ b/src/SCPI_RP.h
@@ -47,6 +47,8 @@ class SCPIRedPitaya {
    */
   void initSocket(Stream *serial);
 
+  void setReadTimeout(uint32_t timeout_ms);
+
   SCPIAio aio;
   SCPIDaisy daisy;
   SCPIDio dio;

--- a/src/common/base_io.cpp
+++ b/src/common/base_io.cpp
@@ -73,6 +73,10 @@ BaseIO::BaseIO() {
 
 BaseIO::~BaseIO() {}
 
+void BaseIO::setReadTimeout(uint32_t timeout_ms) {
+  m_readTimeoutMs = timeout_ms;
+}
+
 int BaseIO::checkParamSeparator() {
   for (scpi_size i = m_bufferReadPos; i < m_bufferSize; i++) {
     if (m_buffer[i] == SCPI_PARAM_SEPARATOR) {
@@ -95,6 +99,7 @@ int BaseIO::checkCommandSeparator() {
 
 int BaseIO::fillBuffer() {
   int end = -1;
+  unsigned long start = millis();
   while (end == -1) {
     end = checkParamSeparator();
     if (end == -1) {
@@ -103,7 +108,11 @@ int BaseIO::fillBuffer() {
     if (end == -1) {
       scpi_size ret = readToBuffer();
       if (ret == 0) {
-        return -1;
+        if (millis() - start >= m_readTimeoutMs) {
+          return -1;
+        }
+      } else {
+        start = millis();
       }
     }
   }

--- a/src/common/base_io.h
+++ b/src/common/base_io.h
@@ -29,6 +29,8 @@ class BaseIO {
   bool writeNumberU64(uint64_t value);
   bool writeNumber(float value, uint8_t pre, uint8_t post);
 
+  void setReadTimeout(uint32_t timeout_ms);
+
   virtual scpi_size write(const uint8_t *_data, scpi_size _size) = 0;
 
   scpi_size write(const char *_data, scpi_size _size);
@@ -36,17 +38,18 @@ class BaseIO {
   uint64_t atou64_dec(const char *str);
   char *uitoa64_dec(uint64_t value, char *str);
 
- protected:
-  int checkParamSeparator();
-  int checkCommandSeparator();
-  int fillBuffer();
+   protected:
+    int checkParamSeparator();
+    int checkCommandSeparator();
+    int fillBuffer();
 
-  virtual scpi_size readToBuffer() = 0;
+    virtual scpi_size readToBuffer() = 0;
 
-  uint8_t m_buffer[BASE_IO_BUFFER_SIZE];
-  scpi_size m_bufferSize = 0;
-  scpi_size m_bufferReadPos = 0;
-};
+    uint8_t m_buffer[BASE_IO_BUFFER_SIZE];
+    scpi_size m_bufferSize = 0;
+    scpi_size m_bufferReadPos = 0;
+    uint32_t m_readTimeoutMs = 5;
+  };
 
 }  // namespace scpi_rp
 


### PR DESCRIPTION
## Summary
- allow configuring a read timeout for BaseIO and expose setter on SCPIRedPitaya
- retry zero-length reads until timeout instead of failing immediately

## Testing
- `arduino-cli version` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed, 403)*
- `g++ -c src/common/base_io.cpp -I./src` *(fails: Arduino.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689c9d5af1088325b0431d261eadd9af